### PR TITLE
Improve setup and defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,3 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
-next-env.d.ts

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-FinnanceAPP
+FinnanceApp
 
 Personal Finance App built with shadcn/ui to help you manage and track all your personal expenses, bills, properties, vehicles, and payment schedules in one place.
 
@@ -30,8 +30,8 @@ Calendar: FullCalendar or React Calendar integration
 
 Clone the repo
 
-git clone https://github.com/your-username/finnanceapp.git
-cd finnanceapp
+git clone https://github.com/your-username/finnance.git
+cd finnance
 
 Install dependencies
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,8 @@
 const config = {
-  plugins: ["@tailwindcss/postcss"],
+  plugins: [
+    "tailwindcss",
+    "autoprefixer",
+  ],
 };
 
 export default config;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -22,5 +22,9 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans);
+}
+
+code, pre {
+  font-family: var(--font-mono);
 }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,7 @@
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <h2 className="text-2xl font-bold">404 - Page Not Found</h2>
+    </div>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,16 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./src/**/*.{ts,tsx}", "./src/app/globals.css"],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: "var(--font-geist-sans)",
+        mono: "var(--font-geist-mono)",
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add MIT license
- expose `next-env.d.ts`
- add custom Tailwind configuration
- use Tailwind and Autoprefixer with PostCSS
- hook up custom fonts in global CSS
- create a simple 404 page
- fix README instructions

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68757a6a79b88330be340125b36ec38b